### PR TITLE
Add "push" command

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,10 +76,9 @@ Be sure to use version control.
 
 **Implemented!**
 
-`stmocli push [<filename>]`
+`stmocli push <filename>`
 
 Pushes the current SQL statements and metadata to re:dash for the given query file.
-If no filename is specified, push data for all queries.
 
 `<filename>` must be a key in the dictionary stored in `.stmocli.conf`
 

--- a/README.md
+++ b/README.md
@@ -48,9 +48,13 @@ Assuming this is the first query being tracked, `.stmocli.conf` would look like 
 
 ```json
 {
-  "poc": {
-    "redash_id": 49741,
-    "filename": "poc.sql"
+  "poc.sql": {
+    "query_id": 49741,
+    "data_source_id": <data source>,
+    "name": <query name>,
+    "description": <query description>,
+    "schedule": <schedule interval in seconds>,
+    "options": <query options>
   }
 }
 ```
@@ -70,14 +74,14 @@ Be sure to use version control.
 
 ## `push` a query
 
-**Not Yet Implemented**
+**Implemented!**
 
-`stmocli push [<id>]`
+`stmocli push [<filename>]`
 
-Pushes the current SQL statements and metadata to re:dash for the given query.
-If no query id is specified, push data for all queries.
+Pushes the current SQL statements and metadata to re:dash for the given query file.
+If no filename is specified, push data for all queries.
 
-`<id>` must be a key in the dictionary stored in `.stmocli.conf`
+`<filename>` must be a key in the dictionary stored in `.stmocli.conf`
 
 # Roadmap
 

--- a/stmocli/cli.py
+++ b/stmocli/cli.py
@@ -2,6 +2,7 @@ from redash_client.client import RedashClient
 from requests.compat import urljoin
 from .conf import Conf
 import click
+import md5
 import os
 import requests
 
@@ -32,24 +33,28 @@ def track(conf, query_id, file_name, redash_api_key):
     # Get query: https://github.com/getredash/redash/blob/1573e06e710733714d47940cc1cb196b8116f670/redash/handlers/api.py#L74
     redash = RedashClient(redash_api_key)
     url_path = 'queries/{}?api_key={}'.format(query_id, redash_api_key)
-    results, response = redash._make_request(
-        requests.get,
-        urljoin(redash.API_BASE_URL, url_path)
-    )
+    try:
+        results, response = redash._make_request(
+            requests.get,
+            urljoin(redash.API_BASE_URL, url_path)
+        )
 
-    query = results['query']
-    with open(file_name, 'w') as outfile:
-        outfile.write(query)
+        query = results['query']
+        with open(file_name, 'w') as outfile:
+            outfile.write(query)
 
-    query_meta = {
-        "query_id": query_id,
-        "data_source_id": results['data_source_id'],
-        "name": results['name'],
-        "description": results['description'],
-        "schedule": results['schedule'],
-        "options": results['options']
-    }
-    conf.add_query(file_name, query_meta)
+        query_meta = {
+            "id": query_id,
+            "data_source_id": results['data_source_id'],
+            "name": results['name'],
+            "description": results['description'],
+            "schedule": results['schedule'],
+            "options": results['options']
+        }
+        conf.add_query(file_name, query_meta)
+        click.echo("Tracking Query ID {} in {}".format(query_id, file_name))
+    except RedashClient.RedashClientException as e:
+        click.echo("Failed to track Query ID {}: {}".format(query_id, e))
 
 
 @cli.command()
@@ -62,14 +67,24 @@ def track(conf, query_id, file_name, redash_api_key):
 def push(conf, file_name, redash_api_key):
     redash = RedashClient(redash_api_key)
 
-    query_meta = conf.get_query(file_name)
-    with open(file_name, 'r') as fin:
-        query = fin.read()
+    try:
+        meta = conf.get_query(file_name)
+        with open(file_name, 'r') as fin:
+            query = fin.read()
 
-    redash.update_query(query_meta['query_id'], query_meta['name'],
-                        query, query_meta['data_source_id'],
-                        query_meta['description'], query_meta['options'])
-
+        try:
+            redash.update_query(meta['id'], meta['name'],
+                                query, meta['data_source_id'],
+                                meta['description'], meta['options'])
+            m = md5.new()
+            m.update(query)
+            click.echo("Query ID {} updated with content from {} (md5 {})".format(
+                meta["id"], file_name, m.hexdigest()))
+        except RedashClient.RedashClientException as e:
+            click.echo("Failed to update query from {}: {}".format(file_name, e))
+    except KeyError as e:
+        click.echo("Failed to update query from {}: No such query, "
+                   "maybe you need to 'track' first".format(file_name))
 
 
 if __name__ == '__main__':

--- a/stmocli/cli.py
+++ b/stmocli/cli.py
@@ -23,26 +23,53 @@ def init(conf):
 @cli.command()
 @pass_conf
 @click.argument('query_id')
-@click.argument('query_name')
+@click.argument('file_name')
 @click.option(
     '--redash_api_key',
     default=lambda: os.environ.get('REDASH_API_KEY', '')
 )
-def track(conf, query_id, query_name, redash_api_key):
+def track(conf, query_id, file_name, redash_api_key):
     # Get query: https://github.com/getredash/redash/blob/1573e06e710733714d47940cc1cb196b8116f670/redash/handlers/api.py#L74
     redash = RedashClient(redash_api_key)
     url_path = 'queries/{}?api_key={}'.format(query_id, redash_api_key)
     results, response = redash._make_request(
-        requests.get, 
-        urljoin(redash.BASE_URL, url_path)
+        requests.get,
+        urljoin(redash.API_BASE_URL, url_path)
     )
-    query = results['query']
 
-    filename = query_name + '.sql'
-    with open(filename, 'w') as outfile:
+    query = results['query']
+    with open(file_name, 'w') as outfile:
         outfile.write(query)
 
-    conf.add_query(query_name, query_id, filename)
+    query_meta = {
+        "query_id": query_id,
+        "data_source_id": results['data_source_id'],
+        "name": results['name'],
+        "description": results['description'],
+        "schedule": results['schedule'],
+        "options": results['options']
+    }
+    conf.add_query(file_name, query_meta)
+
+
+@cli.command()
+@pass_conf
+@click.argument('file_name')
+@click.option(
+    '--redash_api_key',
+    default=lambda: os.environ.get('REDASH_API_KEY', '')
+)
+def push(conf, file_name, redash_api_key):
+    redash = RedashClient(redash_api_key)
+
+    query_meta = conf.get_query(file_name)
+    with open(file_name, 'r') as fin:
+        query = fin.read()
+
+    redash.update_query(query_meta['query_id'], query_meta['name'],
+                        query, query_meta['data_source_id'],
+                        query_meta['description'], query_meta['options'])
+
 
 
 if __name__ == '__main__':

--- a/stmocli/conf.py
+++ b/stmocli/conf.py
@@ -22,12 +22,12 @@ class Conf(object):
         with open(self.path, 'w') as conf_file:
             conf_file.write(json.dumps(self.contents))
 
-    def add_query(self, name, redash_id, filename):
-        if name in self.contents:
-            print('Query, "{}" already tracked!'.format(name))
+    def add_query(self, file_name, query_metadata):
+        if file_name in self.contents:
+            print('Query, "{}" already tracked!'.format(file_name))
         else:
-            self.contents[name] = {
-                'redash_id': redash_id,
-                'filename': filename,
-            }
+            self.contents[file_name] = query_metadata
             self.save()
+
+    def get_query(self, file_name):
+        return self.contents[file_name].copy()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -34,14 +34,13 @@ def test_init(runner):
 
 def test_track(runner):
     query_id = '49741'
-    query_name = 'poc'
-    filename = query_name + '.sql'
+    file_name = 'poc.sql'
 
     with runner.isolated_filesystem():
         with HTTMock(response_content):
             result = runner.invoke(cli.track, [
                 query_id,
-                query_name,
+                file_name,
                 '--redash_api_key',
                 'TOTALLY_FAKE_KEY'
             ])
@@ -49,17 +48,16 @@ def test_track(runner):
         print_debug_for_runner(result)
 
         # Verify we save the query to the right file
-        assert os.path.isfile(filename)
-        with open(filename, 'r') as query:
+        assert os.path.isfile(file_name)
+        with open(file_name, 'r') as query:
             assert "SELECT" in query.read()
 
         # Verify we save the query_id to the config file
         assert os.path.isfile(conf_path)
         with open(conf_path, 'r') as conf_file:
             config = json.loads(conf_file.read())
-            assert query_name in config
-            assert config[query_name]['redash_id'] == query_id
-
+            assert file_name in config
+            assert config[file_name]['query_id'] == query_id
 
 def print_debug_for_runner(result):
     """Helper function for printing click.runner debug tracebacks."""


### PR DESCRIPTION
Add basic support to push queries back to STMO. This requires a few
small changes to "track" to add the required query metadata
fields.