### PR TITLE
Add entry point for CLI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,4 +27,9 @@ setup(
     ],
     tests_require=test_deps,
     extras_require=extras,
+    entry_points={
+        "console_scripts": [
+            ["stmocli=stmocli.cli:cli"]
+        ]
+    },
 )

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     extras_require=extras,
     entry_points={
         "console_scripts": [
-            ["stmocli=stmocli.cli:cli"]
+            "stmocli=stmocli.cli:cli",
         ]
     },
 )


### PR DESCRIPTION
This asks installers to create a stub script named `stmocli` that will invoke the CLI.

Other things this could be named: `stmo`?