### PR TITLE
Ask click not to swallow exceptions

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,12 +1,14 @@
-import traceback
 import hashlib
-import pytest
-import click
 import json
 import os
-from httmock import all_requests, HTTMock
-from redash_client.client import RedashClient
+import traceback
+
+import click
 from click.testing import CliRunner
+from httmock import all_requests, HTTMock
+import pytest
+from redash_client.client import RedashClient
+
 from stmocli import cli
 from stmocli.conf import default_path as conf_path
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,7 @@
+from functools import partial
 import hashlib
 import json
 import os
-import traceback
 
 import click
 from click.testing import CliRunner
@@ -35,14 +35,13 @@ def push_response_fail(url, request):
 
 @pytest.fixture
 def runner():
-    return CliRunner()
+    r = CliRunner()
+    r.invoke = partial(r.invoke, catch_exceptions=False)
+    return r
 
 def test_init(runner):
     with runner.isolated_filesystem():
         result = runner.invoke(cli.init)
-
-        print_debug_for_runner(result)
-
         assert os.path.isfile(conf_path)
 
 def test_track(runner):
@@ -57,8 +56,6 @@ def test_track(runner):
                 '--redash_api_key',
                 'TOTALLY_FAKE_KEY'
             ])
-
-        print_debug_for_runner(result)
 
         # Verify we save the query to the right file
         assert os.path.isfile(file_name)
@@ -140,12 +137,3 @@ def test_push_untracked(runner):
         ])
 
     assert "No such query" in push_result.output
-
-
-def print_debug_for_runner(result):
-    """Helper function for printing click.runner debug tracebacks."""
-    print(result.output)
-    print(result.exc_info)
-    traceback.print_tb(result.exc_info[2])
-    print(result.exit_code)
-    print(result.exception)


### PR DESCRIPTION
This is a bit of a hack, but: by default, click's testrunner just ignores all exceptions from the invoked command, relying on the caller to inspect the exit status and any captured exception manually. This doesn't seem like useful behavior -- instead, let's tell click just to re-raise the exception.

We probably don't intend to assert that a particular exception is thrown by a CLI, but if an exception _is_ thrown, this provides more useful feedback.