### PR TITLE
Add autostubbing to `track`.

### DIFF
--- a/stmocli/cli.py
+++ b/stmocli/cli.py
@@ -1,11 +1,12 @@
-from redash_client.client import RedashClient
-from requests.compat import urljoin
-from .conf import Conf
-import click
 import hashlib
 import os
-import requests
 
+import click
+from redash_client.client import RedashClient
+import requests
+from requests.compat import urljoin
+
+from .conf import Conf
 
 pass_conf = click.make_pass_decorator(Conf, ensure=True)
 

--- a/stmocli/cli.py
+++ b/stmocli/cli.py
@@ -47,7 +47,7 @@ def track(conf, query_id, file_name, redash_api_key):
                 query_id,
                 name_to_stub(results["name"]),
             )
-            file_name = click.prompt("Query filename", default=default_file_name)
+            file_name = click.prompt("Filename for tracked query SQL", default=default_file_name)
 
         query = results['query']
         with open(file_name, 'w') as outfile:

--- a/stmocli/cli.py
+++ b/stmocli/cli.py
@@ -7,6 +7,7 @@ import requests
 from requests.compat import urljoin
 
 from .conf import Conf
+from .util import name_to_stub
 
 pass_conf = click.make_pass_decorator(Conf, ensure=True)
 
@@ -25,7 +26,7 @@ def init(conf):
 @cli.command()
 @pass_conf
 @click.argument('query_id')
-@click.argument('file_name')
+@click.argument('file_name', required=False)
 @click.option(
     '--redash_api_key',
     default=lambda: os.environ.get('REDASH_API_KEY', '')
@@ -40,6 +41,12 @@ def track(conf, query_id, file_name, redash_api_key):
             requests.get,
             urljoin(redash.API_BASE_URL, url_path)
         )
+
+        if not file_name:
+            file_name = "{}_{}.sql".format(
+                query_id,
+                name_to_stub(results["name"]),
+            )
 
         query = results['query']
         with open(file_name, 'w') as outfile:

--- a/stmocli/cli.py
+++ b/stmocli/cli.py
@@ -43,10 +43,11 @@ def track(conf, query_id, file_name, redash_api_key):
         )
 
         if not file_name:
-            file_name = "{}_{}.sql".format(
+            default_file_name = "{}_{}.sql".format(
                 query_id,
                 name_to_stub(results["name"]),
             )
+            file_name = click.prompt("Query filename", default=default_file_name)
 
         query = results['query']
         with open(file_name, 'w') as outfile:

--- a/stmocli/cli.py
+++ b/stmocli/cli.py
@@ -43,8 +43,7 @@ def track(conf, query_id, file_name, redash_api_key):
         )
 
         if not file_name:
-            default_file_name = "{}_{}.sql".format(
-                query_id,
+            default_file_name = "{}.sql".format(
                 name_to_stub(results["name"]),
             )
             file_name = click.prompt("Filename for tracked query SQL", default=default_file_name)

--- a/stmocli/util.py
+++ b/stmocli/util.py
@@ -1,0 +1,10 @@
+import re
+
+
+def name_to_stub(name):
+    """
+    Makes a filename-safe stub from an arbitrary title.
+
+    Ex.: "My Life (And Hard Times)" -> "my_life_and_hard_times"
+    """
+    return re.sub(r"[^A-Za-z0-9]+", "_", name).strip("_").lower()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -74,6 +74,21 @@ def test_track(runner):
             assert config[file_name]['id'] == query_id
 
 
+def test_track_autostub(runner):
+    query_id = '49741'
+    expected_filename = query_id + "_st_mocli_poc.sql"
+
+    with runner.isolated_filesystem():
+        with HTTMock(response_content):
+            runner.invoke(cli.track, [
+                query_id,
+                "--redash_api_key",
+                "TOTALLY_FAKE_KEY",
+            ])
+
+        assert os.path.isfile(expected_filename)
+
+
 def setup_tracked_query(runner, query_id, file_name):
     with HTTMock(response_content):
         runner.invoke(cli.track, [

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -76,7 +76,7 @@ def test_track(runner):
 
 def test_track_autostub(runner):
     query_id = '49741'
-    expected_filename = query_id + "_st_mocli_poc.sql"
+    expected_filename = "st_mocli_poc.sql"
 
     with runner.isolated_filesystem():
         with HTTMock(response_content):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -80,11 +80,12 @@ def test_track_autostub(runner):
 
     with runner.isolated_filesystem():
         with HTTMock(response_content):
-            runner.invoke(cli.track, [
-                query_id,
-                "--redash_api_key",
-                "TOTALLY_FAKE_KEY",
-            ])
+            runner.invoke(
+                cli.track,
+                [query_id,
+                 "--redash_api_key",
+                 "TOTALLY_FAKE_KEY"],
+                input="\n")
 
         assert os.path.isfile(expected_filename)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,6 @@
+from stmocli.util import name_to_stub
+
+
+def test_name_to_stub():
+    assert name_to_stub("My Life (and Hard Times)") == "my_life_and_hard_times"
+    assert name_to_stub("#123: Foo") == "123_foo"


### PR DESCRIPTION
Works like:

```
tsmith-0yhv2t:tsmith stmocli-queries (master)$ stmocli track 1234
Tracking Query ID 1234 in 1234_copy_of_426_android_release_retention_by_experiment_cohort_onboarding_2.sql
```

Closes #17.