### PR TITLE
Move --redash-api-key onto parent cli()

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,26 @@ In re:dash, it's difficult to get review, track revisions, or collaborate on que
 St. Mocli is currently [vaporware](https://en.wikipedia.org/wiki/Vaporware),
 so this workflow is going to change.
 
+## Preliminaries
+
+You should have a Redash API key to perform most operations.
+You can get one from your
+[Redash user settings page](https://sql.telemetry.mozilla.org/users/me).
+
+Then, add something like:
+
+```bash
+export REDASH_API_KEY="Tua1aith1ay9roh5thuGhoh6sa3raene"
+```
+
+to your ~/.bash_profile, or pass the key to stmocli on the command line like:
+
+```bash
+stmocli --redash-api-key Tua1aith1ay9roh5thuGhoh6sa3raene view query.sql
+```
+
+Note that `--redash-api-key` has to come before the verb on the command line.
+
 ## `init` a directory
 
 **Implemented**!

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
     packages=find_packages(exclude=['tests']),
     include_package_data=True,
     install_requires=[
+        "attrs",
         "redash-client",
         "click",
     ],

--- a/stmocli/cli.py
+++ b/stmocli/cli.py
@@ -103,11 +103,11 @@ def push(shared, file_name):
 
 
 @cli.command()
-@pass_conf
+@click.pass_obj
 @click.argument('file_name')
-def view(conf, file_name):
+def view(shared, file_name):
     try:
-        meta = conf.get_query(file_name)
+        meta = shared.conf.get_query(file_name)
     except KeyError:
         click.echo("Couldn't find a query ID for {}: No such query, "
                    "maybe you need to 'track' first".format(file_name),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -180,7 +180,7 @@ def test_push_untracked(runner):
 @patch("click.launch")
 def test_view_unknown(launch, runner):
     with runner.isolated_filesystem():
-        result = runner.invoke(cli.view, ["spam"])
+        result = runner.invoke(cli.cli, ["view", "spam"])
         assert result.exit_code != 0
         assert "No such query" in result.output
         launch.assert_not_called()
@@ -190,7 +190,7 @@ def test_view_unknown(launch, runner):
 def test_view(launch, runner):
     with runner.isolated_filesystem():
         setup_tracked_query(runner, "123", "query.sql")
-        result = runner.invoke(cli.view, ["query.sql"])
+        result = runner.invoke(cli.cli, ["view", "query.sql"])
     assert result.exit_code == 0
     launch.assert_called_once()
     args, _kwargs = launch.call_args


### PR DESCRIPTION
We're redefining redash-api-key a lot, we don't complain if it isn't set, and we need it for most operations, so let's just push it onto the parent CLI group along with the conf.

Side effects of this are that --redash-api-key has to be specified between `stmocli` and the subcommand -- i.e. like `stmocli --redash-api-key foo track bar`.

It also means we have to call `cli.cli()` from the tests and not e.g. `cli.track()`.

Alternatives include defining a new decorator that just adds the redash_api_key parameter to a CLI subcommand.