### PR TITLE
Refactor all the things

### DIFF
--- a/stmocli/cli.py
+++ b/stmocli/cli.py
@@ -2,20 +2,10 @@ import hashlib
 import os
 import sys
 
-import attr
 import click
-from redash_client.client import RedashClient
-import requests
-from requests.compat import urljoin
 
-from .conf import Conf
+from .stmo import STMO
 from .util import name_to_stub
-
-
-@attr.s
-class SharedOptions(object):
-    redash_api_key = attr.ib()
-    conf = attr.ib()
 
 
 @click.group()
@@ -25,95 +15,70 @@ class SharedOptions(object):
 )
 @click.pass_context
 def cli(ctx, redash_api_key):
-    ctx.obj = SharedOptions(
-        redash_api_key=redash_api_key,
-        conf=Conf(),
-    )
+    ctx.obj = STMO(redash_api_key)
 
 
 @cli.command()
 @click.pass_obj
-def init(shared):
-    shared.conf.init_file()
+def init(stmo):
+    stmo.conf.init_file()
 
 
 @cli.command()
 @click.pass_obj
 @click.argument('query_id')
 @click.argument('file_name', required=False)
-def track(shared, query_id, file_name):
-    # Get query:
-    # https://github.com/getredash/redash/blob/1573e06e710733714d47940cc1cb196b8116f670/redash/handlers/api.py#L74
-    redash = RedashClient(shared.redash_api_key)
-    url_path = 'queries/{}?api_key={}'.format(query_id, shared.redash_api_key)
-    try:
-        results, response = redash._make_request(
-            requests.get,
-            urljoin(redash.API_BASE_URL, url_path)
+def track(stmo, query_id, file_name):
+    def make_file_name(query):
+        if file_name:
+            return file_name
+        default_file_name = "{}.sql".format(
+            name_to_stub(query["name"]),
         )
+        return click.prompt("Filename for tracked query SQL", default=default_file_name)
 
-        if not file_name:
-            default_file_name = "{}.sql".format(
-                name_to_stub(results["name"]),
-            )
-            file_name = click.prompt("Filename for tracked query SQL", default=default_file_name)
-
-        query = results['query']
-        with open(file_name, 'w') as outfile:
-            outfile.write(query)
-
-        query_meta = {
-            "id": query_id,
-            "data_source_id": results['data_source_id'],
-            "name": results['name'],
-            "description": results['description'],
-            "schedule": results['schedule'],
-            "options": results['options']
-        }
-        shared.conf.add_query(file_name, query_meta)
-        click.echo("Tracking Query ID {} in {}".format(query_id, file_name))
-    except RedashClient.RedashClientException as e:
+    try:
+        stmo.track_query(query_id, make_file_name)
+    except STMO.RedashClientException as e:
         click.echo("Failed to track Query ID {}: {}".format(query_id, e))
+        sys.exit(1)
+
+    click.echo("Tracking Query ID {} in {}".format(query_id, file_name))
 
 
 @cli.command()
 @click.pass_obj
 @click.argument('file_name')
-def push(shared, file_name):
-    redash = RedashClient(shared.redash_api_key)
-
+def push(stmo, file_name):
     try:
-        meta = shared.conf.get_query(file_name)
-        with open(file_name, 'r') as fin:
-            query = fin.read()
-
-        try:
-            redash.update_query(meta['id'], meta['name'],
-                                query, meta['data_source_id'],
-                                meta['description'], meta['options'])
-
-            m = hashlib.md5(query.encode("utf-8"))
-            click.echo("Query ID {} updated with content from {} (md5 {})".format(
-                meta["id"], file_name, m.hexdigest()))
-        except RedashClient.RedashClientException as e:
-            click.echo("Failed to update query from {}: {}".format(file_name, e))
+        queryinfo = stmo.push_query(file_name)
+    except stmo.RedashClientException as e:
+        click.echo("Failed to update query from {}: {}".format(file_name, e))
+        sys.exit(1)
     except KeyError as e:
         click.echo("Failed to update query from {}: No such query, "
                    "maybe you need to 'track' first".format(file_name))
+        sys.exit(1)
+
+    with open(file_name, "rt") as f:
+        query = f.read()
+
+    m = hashlib.md5(query.encode("utf-8"))
+    click.echo("Query ID {} updated with content from {} (md5 {})".format(
+        queryinfo["id"], file_name, m.hexdigest()))
 
 
 @cli.command()
 @click.pass_obj
 @click.argument('file_name')
-def view(shared, file_name):
+def view(stmo, file_name):
     try:
-        meta = shared.conf.get_query(file_name)
+        url = stmo.url_for_query(file_name)
     except KeyError:
         click.echo("Couldn't find a query ID for {}: No such query, "
                    "maybe you need to 'track' first".format(file_name),
                    err=True)
         sys.exit(1)
-    url = urljoin(RedashClient.BASE_URL, "queries/{id}".format(**meta))
     click.launch(url)
 
 

--- a/stmocli/cli.py
+++ b/stmocli/cli.py
@@ -65,7 +65,7 @@ def push(stmo, file_name):
 
     m = hashlib.md5(query.encode("utf-8"))
     click.echo("Query ID {} updated with content from {} (md5 {})".format(
-        queryinfo["id"], file_name, m.hexdigest()))
+        queryinfo.id, file_name, m.hexdigest()))
 
 
 @cli.command()

--- a/stmocli/conf.py
+++ b/stmocli/conf.py
@@ -1,6 +1,8 @@
 import json
 import os
 
+import attr
+
 default_path = './.stmocli.conf'
 
 
@@ -27,8 +29,34 @@ class Conf(object):
         if file_name in self.contents:
             print('Query, "{}" already tracked!'.format(file_name))
         else:
-            self.contents[file_name] = query_metadata
+            self.contents[file_name] = query_metadata.to_dict()
             self.save()
 
     def get_query(self, file_name):
-        return self.contents[file_name].copy()
+        return QueryInfo.from_dict(self.contents[file_name])
+
+
+@attr.s
+class QueryInfo(object):
+    id = attr.ib(converter=str)
+    data_source_id = attr.ib()
+    name = attr.ib()
+    description = attr.ib()
+    schedule = attr.ib()
+    options = attr.ib()
+
+    @id.validator
+    def id_is_not_none(instance, attribute, value):
+        if value is None:
+            raise ValueError("id may not be None")
+
+    @classmethod
+    def from_dict(cls, d):
+        """Instantiate a QueryInfo from a dictionary.
+
+        Different from QueryInfo(**d) because this ignores missing keys or extra values in d."""
+        fields = [field.name for field in attr.fields(cls)]
+        return cls(**{k: d.get(k, None) for k in fields})
+
+    def to_dict(self):
+        return attr.asdict(self)

--- a/stmocli/stmo.py
+++ b/stmocli/stmo.py
@@ -1,0 +1,89 @@
+from redash_client.client import RedashClient
+import requests
+from requests.compat import urljoin
+
+from .conf import Conf
+
+
+class STMO(object):
+    """The STMO half of stmocli.
+
+    This class is responsible for all of stmocli's functionality that does not involve
+    accepting input from the user or displaying the results.
+    """
+    RedashClientException = RedashClient.RedashClientException
+
+    def __init__(self, redash_api_key, conf=None):
+        self.conf = conf or Conf()
+        self._redash = RedashClient(redash_api_key)
+        self.redash_api_key = redash_api_key
+
+    def get_query(self, query_id):
+        """Fetches information about a query from Redash.
+
+        Args:
+            query_id (int, str): Redash query ID
+
+        Returns:
+            query (dict): The response from redash, representing a Query model.
+        """
+        # Get query:
+        # https://github.com/getredash/redash/blob/1573e06e710733714d47940cc1cb196b8116f670/redash/handlers/api.py#L74
+        url_path = "queries/{}?api_key={}".format(query_id, self.redash_api_key)
+        results, response = self._redash._make_request(
+            requests.get,
+            urljoin(self._redash.API_BASE_URL, url_path)
+        )
+        return results
+
+    def track_query(self, query_id, file_name):
+        """Saves a query to disk and adds it to the conf file.
+
+        Args:
+            query_id (int, str): Redash query ID
+            file_name (str, callable): Name of the file_name to write the query out to.
+                If callable, receives the Redash query object as a parameter.
+
+        Returns:
+            query (dict): The response from redash, representing a Query model.
+        """
+        query = self.get_query(query_id)
+        query_file_name = file_name(query) if callable(file_name) else file_name
+        with open(query_file_name, "w") as outfile:
+            outfile.write(query["query"])
+        query_meta = {
+            "id": query_id,
+            "data_source_id": query["data_source_id"],
+            "name": query["name"],
+            "description": query["description"],
+            "schedule": query["schedule"],
+            "options": query["options"]
+        }
+        self.conf.add_query(query_file_name, query_meta)
+        return query
+
+    def push_query(self, file_name):
+        """Replaces the SQL on Redash with the local version of a tracked query.
+
+        Args:
+            file_name (str): file_name of a tracked query
+
+        Returns:
+            meta (dict): The query metadata
+
+        Throws:
+            KeyError: if query is not tracked
+            RedashClientException
+        """
+        meta = self.conf.get_query(file_name)
+        with open(file_name, 'r') as fin:
+            sql = fin.read()
+        self._redash.update_query(
+            meta['id'], meta['name'],
+            sql, meta['data_source_id'],
+            meta['description'], meta['options'])
+        return meta
+
+    def url_for_query(self, file_name):
+        meta = self.conf.get_query(file_name)
+        return urljoin(RedashClient.BASE_URL, "queries/{id}".format(**meta))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -188,10 +188,13 @@ def test_view_unknown(launch, runner):
 
 @patch("click.launch")
 def test_view(launch, runner):
+    query_id = '49741'
+    file_name = 'poc.sql'
+
     with runner.isolated_filesystem():
-        setup_tracked_query(runner, "123", "query.sql")
-        result = runner.invoke(cli.cli, ["view", "query.sql"])
+        setup_tracked_query(runner, query_id, file_name)
+        result = runner.invoke(cli.cli, ["view", file_name])
     assert result.exit_code == 0
     launch.assert_called_once()
     args, _kwargs = launch.call_args
-    assert args[0].endswith("/123")
+    assert args[0].endswith("/" + query_id)


### PR DESCRIPTION
This is too big and I'm not sure I'm sold on the design, but this is intended to accomplish a couple of things:

* Avoid doing work in the CLI functions

Treat the CLI as a view on a controller object. The `cli` module does the work of accepting user input and presenting tidy error messages; the `stmo` module does all the real work.

This will make it easier to do things like implement #26, because we can reuse the `track` logic.

I'm not sure what the right error-handling discipline is; right now, the `stmo` layer just passes all the exceptions up to the CLI layer, which could be better.

* Solidify the query metadata into a class

Instead of passing around a dict with well-known keys, define a class.