### PR TITLE
Init should be a no-op if config already exists

### DIFF
--- a/stmocli/conf.py
+++ b/stmocli/conf.py
@@ -17,8 +17,11 @@ class Conf(object):
                 self.contents = json.loads(conf_file.read())
 
     def init_file(self):
-        with open(self.path, 'a') as conf_file:
+        if os.path.exists(self.path):
+            return False
+        with open(self.path, 'w') as conf_file:
             conf_file.write(json.dumps({}))
+        return True
 
     def save(self):
         with open(self.path, 'w') as conf_file:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -53,6 +53,21 @@ def test_init(runner):
         assert os.path.isfile(conf_path)
 
 
+def test_init_is_idempotent(runner):
+    spam = '{"spam": "spam"}\n'
+    with runner.isolated_filesystem():
+        assert not os.path.exists(conf_path)
+        r1 = runner.invoke(cli.cli, ["init"])
+        assert r1.exit_code == 0
+        assert os.path.exists(conf_path)
+        with open(conf_path, "w") as f:
+            f.write(spam)
+        r2 = runner.invoke(cli.cli, ["init"])
+        assert r2.exit_code == 0
+        with open(conf_path, "r") as f:
+            assert f.read() == spam
+
+
 def test_track(runner):
     query_id = '49741'
     file_name = 'poc.sql'


### PR DESCRIPTION
The current behavior if `init` is run twice is to append an empty object
to the configuration file. Let's check whether the file exists or not,
and do nothing if it's already present.