### PR TITLE
Add `fork` command

### DIFF
--- a/stmocli/cli.py
+++ b/stmocli/cli.py
@@ -82,5 +82,34 @@ def view(stmo, file_name):
     click.launch(url)
 
 
+@cli.command()
+@click.pass_obj
+@click.argument('query_to_fork')
+@click.argument('new_query_file_name')
+def fork(stmo, query_to_fork, new_query_file_name):
+    if os.path.exists(query_to_fork):
+        try:
+            query_id = stmo.conf.get_query(query_to_fork).id
+        except KeyError:
+            click.echo("Couldn't find a query ID for {}. "
+                       "Did you need to 'track' it?".format(query_to_fork),
+                       err=True)
+            sys.exit(1)
+    elif query_to_fork.isnumeric():
+        query_id = query_to_fork
+    else:
+        click.echo("Couldn't fork that query; no file or query named {}.".format(query_to_fork),
+                   err=True)
+        sys.exit(1)
+
+    try:
+        result = stmo.fork_query(query_id, new_query_file_name)
+    except STMO.RedashClientException:
+        click.echo("Couldn't find a query with ID {} on the server.".format(query_id), err=True)
+        sys.exit(1)
+
+    click.echo("Forked query {} to {}: {}".format(query_id, new_query_file_name, result.name))
+
+
 if __name__ == '__main__':
     cli()

--- a/stmocli/stmo.py
+++ b/stmocli/stmo.py
@@ -45,7 +45,7 @@ class STMO(object):
                 If callable, receives the Redash query object as a parameter.
 
         Returns:
-            query (dict): The response from redash, representing a Query model.
+            query_info (QueryInfo): Metadata about the tracked query
         """
         query = self.get_query(query_id)
         query_file_name = file_name(query) if callable(file_name) else file_name
@@ -53,7 +53,7 @@ class STMO(object):
             outfile.write(query["query"])
         query_info = QueryInfo.from_dict(query)
         self.conf.add_query(query_file_name, query_info)
-        return query
+        return query_info
 
     def push_query(self, file_name):
         """Replaces the SQL on Redash with the local version of a tracked query.
@@ -81,3 +81,8 @@ class STMO(object):
     def url_for_query(self, file_name):
         meta = self.conf.get_query(file_name)
         return urljoin(RedashClient.BASE_URL, "queries/{}".format(meta.id))
+
+    def fork_query(self, query_id, new_query_file_name):
+        result = self._redash.fork_query(query_id)
+        fork = self.track_query(result["id"], new_query_file_name)
+        return fork

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -225,7 +225,6 @@ def test_fork(runner):
         setup_tracked_query(runner, query_id, file_name)
         with HTTMock(fork_response, response_content):
             result = runner.invoke(cli.cli, ["fork", file_name, "fork.sql"])
-        assert result.exit_code == 0
         assert os.path.exists("fork.sql")
         assert Conf().get_query("fork.sql")
     assert result.exit_code == 0
@@ -234,15 +233,17 @@ def test_fork(runner):
 def test_fork_rejects_bogus_filename(runner):
     with runner.isolated_filesystem():
         result = runner.invoke(cli.cli, ["fork", "spam", "fork.sql"])
-        assert result.exit_code == 1
-        assert not os.path.exists("fork.sql")
+    assert result.exit_code == 1
+    assert not os.path.exists("fork.sql")
+    assert "no file or query" in result.output
 
 
 def test_fork_handles_404(runner):
     with runner.isolated_filesystem():
         with HTTMock(not_found_response):
             result = runner.invoke(cli.cli, ["fork", "99999", "fork.sql"])
-        assert result.exit_code == 1
+    assert result.exit_code == 1
+    assert "Couldn't find a query with ID" in result.output
 
 
 def test_fork_rejects_untracked_file(runner):
@@ -250,5 +251,5 @@ def test_fork_rejects_untracked_file(runner):
         with open("spam.sql", "w") as f:
             f.write("eggs")
         result = runner.invoke(cli.cli, ["fork", "spam.sql", "fork.sql"])
-        assert result.exit_code == 1
-        assert "track" in result.output
+    assert result.exit_code == 1
+    assert "track" in result.output


### PR DESCRIPTION
Forks a STMO query (by tracked file name or query ID) and tracks the fork.