### PR TITLE
Add docstrings

### DIFF
--- a/stmocli/cli.py
+++ b/stmocli/cli.py
@@ -117,7 +117,7 @@ def view(stmo, file_name):
 @click.argument('query_to_fork')
 @click.argument('new_query_file_name')
 def fork(stmo, query_to_fork, new_query_file_name):
-    """Copies a STMO  query and tracks the result.
+    """Copies a STMO query and tracks the result.
 
     QUERY_TO_FORK: Either the filename of a query that's already tracked,
     or the numeric ID of any redash query.


### PR DESCRIPTION
Add docstrings to populate click's help text.

Example output:

```
(stmocli) tsmith-0yhv2t:tsmith stmocli (docstrings)$ stmocli -h
Usage: stmocli [OPTIONS] COMMAND [ARGS]...

  St. Mocli is a command-line interface for sql.telemetry.mozilla.org.

Options:
  --redash_api_key TEXT  A redash user API key, from your user settings page.
                         Defaults to the value of the REDASH_API_KEY
                         environment variable.
  -h, --help             Show this message and exit.

Commands:
  fork   Copies a STMO query and tracks the result.
  init   Initializes a repository.
  push   Uploads a tracked query to STMO.
  track  Adds a STMO query to the local repository.
  view   Opens a query in a browser.
```

```
(stmocli) tsmith-0yhv2t:tsmith stmocli (docstrings)$ stmocli fork -h
Usage: stmocli fork [OPTIONS] QUERY_TO_FORK NEW_QUERY_FILE_NAME

  Copies a STMO query and tracks the result.

  QUERY_TO_FORK: Either the filename of a query that's already tracked, or
  the numeric ID of any redash query.

  NEW_QUERY_FILE_NAME: The filename to use for the new query's SQL.

Options:
  -h, --help  Show this message and exit.
```