### PR TITLE
add csv functionality

### DIFF
--- a/stmocli/cli.py
+++ b/stmocli/cli.py
@@ -147,11 +147,12 @@ def fork(stmo, query_to_fork, new_query_file_name):
 
     click.echo("Forked query {} to {}: {}".format(query_id, new_query_file_name, result.name))
 
+
 @cli.command()
 @click.pass_obj
 @click.argument('query_id')
 @click.argument('file_name', required=False)
-def csv(stmo, query_id, file_name):
+def write_csv(stmo, query_id, file_name):
     """gets the dataset resulting from the query_id and writes to a csv.
     data must already exist, this does not execute the query on the server.
     csv will have variable names as first row.

--- a/stmocli/cli.py
+++ b/stmocli/cli.py
@@ -174,5 +174,6 @@ def write_csv(stmo, query_id, file_name):
         dict_writer.writeheader()
         dict_writer.writerows(results)
 
+
 if __name__ == '__main__':
     cli()

--- a/stmocli/cli.py
+++ b/stmocli/cli.py
@@ -167,9 +167,10 @@ def write_csv(stmo, query_id, file_name):
     except STMO.RedashClientException:
         click.echo("Couldn't find a query with ID {} on the server.".format(query_id), err=True)
         sys.exit(1)
+        return
     fn = file_name if file_name else query_name + '.csv'
     headers = results[0].keys()
-    with open(fn, 'wb') as output_file:
+    with open(fn, 'w') as output_file:
         dict_writer = csv.DictWriter(output_file, headers)
         dict_writer.writeheader()
         dict_writer.writerows(results)

--- a/stmocli/stmo.py
+++ b/stmocli/stmo.py
@@ -86,3 +86,27 @@ class STMO(object):
         result = self._redash.fork_query(query_id)
         fork = self.track_query(result["id"], new_query_file_name)
         return fork
+
+    def get_results(self, query_id):
+        """Pull the existing dataset from a query using the query id
+        Doesn't have to be tracked - we will pull the query syntax from stmo
+        and use that.
+
+        Args:
+            query_id: redash id of the query
+
+        Returns:
+            1. The name of the query, to be used for csv filenames if desired
+            2. List of dicts, one dict per row of results. Dicts are keyed by
+            column labels of the returned data.
+
+        Raises:
+            RedashClientException if query id not found on redash
+        """
+        query = self.get_query(query_id)
+        sql_query = query["query"]
+        query_info = QueryInfo.from_dict(query)
+        data_source_id = query_info.data_source_id
+        query_name = query_info.name
+        results = self._redash.get_query_results(sql_query, data_source_id)
+        return(query_name, results)

--- a/tests/data/example_query_results_response.json
+++ b/tests/data/example_query_results_response.json
@@ -1,0 +1,33 @@
+{
+  "query_result":
+  {
+    "retrieved_at": "2018-04-18T18:49:05.036028+00:00",
+    "query_hash": "af24c135608b8bd58ab58c70391d3633",
+    "query": "SELECT\\n    normalized_channel\\nFROM longitudinal\\nLIMIT 10",
+    "runtime": 6.47777,
+    "data": {
+      "rows": [
+        {"normalized_channel": "release"},
+        {"normalized_channel": "release"},
+        {"normalized_channel": "release"},
+        {"normalized_channel": "release"},
+        {"normalized_channel": "release"},
+        {"normalized_channel": "release"},
+        {"normalized_channel": "release"},
+        {"normalized_channel": "release"},
+        {"normalized_channel": "release"},
+        {"normalized_channel": "release"}
+        ],
+      "columns":
+        [
+          {
+            "friendly_name": "normalized_channel",
+            "type": "string",
+            "name": "normalized_channel"
+          }
+        ]
+      },
+    "id": 3792539,
+    "data_source_id": 1
+  }
+}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -279,7 +279,6 @@ def test_fork_rejects_untracked_file(runner):
         with open("spam.sql", "w") as f:
             f.write("eggs")
         result = runner.invoke(cli.cli, ["fork", "spam.sql", "fork.sql"])
-    print(result.exit_code)
     assert result.exit_code == 1
     assert "track" in result.output
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,7 @@
 from functools import partial
 import hashlib
 import json
+import csv
 import os
 
 try:
@@ -19,6 +20,10 @@ from stmocli.conf import Conf
 
 with open('tests/data/example_query_response.json', 'rt') as infile:
     example_response = infile.read()
+
+
+with open('tests/data/example_query_results_response.json', 'rt') as infile:
+    example_result_response = infile.read()
 
 
 @all_requests
@@ -50,6 +55,14 @@ def fork_response(url, request):
             'query': 'SELECT * FROM foo',
             'data_source_id': 0,
         })}
+
+
+@urlmatch(path=r'.*query_results')
+def csv_response(url, request):
+    return {
+        'status_code': 200,
+        'content': example_result_response
+    }
 
 
 @all_requests
@@ -266,5 +279,48 @@ def test_fork_rejects_untracked_file(runner):
         with open("spam.sql", "w") as f:
             f.write("eggs")
         result = runner.invoke(cli.cli, ["fork", "spam.sql", "fork.sql"])
+    print(result.exit_code)
     assert result.exit_code == 1
     assert "track" in result.output
+
+
+def test_csv_with_filename(runner):
+    query_id = '49741'
+    file_name = 'poc.csv'
+
+    with runner.isolated_filesystem():
+        with HTTMock(csv_response, response_content):
+            result = runner.invoke(cli.cli, ["write_csv", query_id, file_name])
+            assert os.path.isfile(file_name)
+            with open('poc.csv', 'r') as csvfile:
+                cr = csv.DictReader(csvfile)
+                # check that the file's header is what it should be
+                assert cr.fieldnames[0] == 'normalized_channel'
+                # check that the first row of the file is what it should be
+                assert next(cr)['normalized_channel'] == 'release'
+    assert result.exit_code == 0
+
+
+def test_csv_without_filename(runner):
+    query_id = '49741'
+
+    with runner.isolated_filesystem():
+        with HTTMock(csv_response, response_content):
+            result = runner.invoke(cli.cli, ["write_csv", query_id])
+            assert os.path.isfile('St. Mocli POC.csv')
+            with open('St. Mocli POC.csv', 'r') as csvfile:
+                cr = csv.DictReader(csvfile)
+                # check that the file's header is what it should be
+                assert cr.fieldnames[0] == 'normalized_channel'
+                # check that the first row of the file is what it should be
+                assert next(cr)['normalized_channel'] == 'release'
+    assert result.exit_code == 0
+
+
+def test_csv_bad_query_id(runner):
+    query_id = 'n0taQu3ry'
+
+    with runner.isolated_filesystem():
+        result = runner.invoke(cli.cli, ["write_csv", query_id])
+    assert result.exit_code == 1
+    assert "server" in result.output


### PR DESCRIPTION
addresses https://github.com/mozilla/stmocli/issues/25

this works for me locally. there might need to be better error handling, e.g. if the query exists on the server but doesn't have any data associated with it (I didn't test that). also didn't test with very large datasets.

also, this doesn't require that the query be tracked in the conf file. 
